### PR TITLE
Fix data being dropped if application crashes when KdbEnvelope is not empty

### DIFF
--- a/Adapter/src/main/java/uk/co/aquaq/kdb/adapter/utils/AdapterProperties.java
+++ b/Adapter/src/main/java/uk/co/aquaq/kdb/adapter/utils/AdapterProperties.java
@@ -14,6 +14,7 @@ public class AdapterProperties {
   private int coreAffinity;
   private String chronicleSource;
   private String adapterTailerName;
+  private String adapterSentTailerName;
   private String adapterMessageType;
   private String adapterMessageFilterField;
   private String adapterMessageFilterIn;
@@ -35,6 +36,7 @@ public class AdapterProperties {
     setCoreAffinity(Integer.parseInt(props.getProperty("adapter.coreAffinity", "-1")));
     setChronicleSource(props.getProperty("chronicle.source"));
     setAdapterTailerName(props.getProperty("chronicle.tailerName"));
+    setAdapterSentTailerName(props.getProperty("chronicle.sentTailerName"));
     setAdapterMessageType(props.getProperty("adapter.messageType"));
     setAdapterMessageFilterField(props.getProperty("adapter.messageFilterField", ""));
     setAdapterMessageFilterIn(props.getProperty("adapter.messageFilterIn", ""));

--- a/Adapter/src/main/resources/application.properties
+++ b/Adapter/src/main/resources/application.properties
@@ -26,8 +26,10 @@ adapter.messageType=QUOTE
 # Filesystem location of Chronicle queue to process
 chronicle.source=C:\\ChronicleQueue\\Producer\\quote
 
-# Named Tailed name. Allows re-start.
+# Named Tailer name. Allows re-start.
 chronicle.tailerName=quoteTailer
+# Named Tailer name. Tracks the last excerpt sent to Kdb.
+chronicle.sentTailerName=quoteSentTailer
 
 # Kdb connection details
 kdb.host=localhost

--- a/Adapter/src/test/resources/application.properties
+++ b/Adapter/src/test/resources/application.properties
@@ -26,8 +26,10 @@ adapter.waitTime.whenNoMsgs=50
 # Filesystem location of Chronicle queue to process
 chronicle.source=C:\\ChronicleQueue\\Producer\\quote
 
-# Named Tailed name. Allows re-start.
+# Named Tailer name. Allows re-start.
 chronicle.tailerName=quoteTailer
+# Named Tailer name. Tracks the last excerpt sent to Kdb.
+chronicle.sentTailerName=quoteSentTailer
 
 # Kdb connection details
 kdb.host=localhost

--- a/README.md
+++ b/README.md
@@ -324,3 +324,9 @@ Whilst there are some generic aspects to the adapter that are configurable e.g. 
 The scenario used was based on our quote messages. The messages were generated in a specific, known format, added to the queue in a specific manner, i.e. as a self-describing message. This allowed the adapter to map known fields from the source message to known fields in the destination object. Finally, the kdb+ table used was structured specifically for quote data.
 
 The quote adapter example that has been completed, should be considered as a base framework to develop further message specific adapters from Chronicle Queue into kdb+. 
+
+# Release Notes
+
+### Version 1.1.0
+
+Fixed an issue where messages are dropped from the Chronicle Queue if the application restarts when there are messages in KdbEnvelope that have not been sent to kdb+.


### PR DESCRIPTION
Create a second ExcerptTailer to keep track of records that are sent to KDB. Remove unused code from ChronicleToKdbAdapter.trySend().